### PR TITLE
Add missing private vars

### DIFF
--- a/src/mz/scenes/Scene_Title.hx
+++ b/src/mz/scenes/Scene_Title.hx
@@ -2,9 +2,30 @@ package mz.scenes;
 
 import mz.core.Rectangle;
 import mz.core.Sprite;
+import mz.windows.Window_TitleCommand;
 
 @:native("Scene_Title")
 extern class Scene_Title extends Scene_Base {
+ /**
+  * The command window for title scene commands like new game, continue, or options.
+  */
+ private var _commandWindow: Window_TitleCommand;
+
+ /**
+  * The background sprite which loads the $dataSystem.title1Name image.
+  */
+ private var _backSprite1: Sprite;
+
+ /**
+  * The background sprite which loads the $dataSystem.title2Name image.
+  */
+ private var _backSprite2: Sprite;
+
+ /**
+  * The sprite which holds the game title text.
+  */
+ private var _gameTitleSprite: Sprite;
+
  /**
   * Creates the title scene background.
   */

--- a/src/mz/scenes/Scene_Title.hx
+++ b/src/mz/scenes/Scene_Title.hx
@@ -9,6 +9,30 @@ extern class Scene_Title extends Scene_Base {
  /**
   * The command window for title scene commands like new game, continue, or options.
   */
+ @:native("_commandWindow")
+ public var __commandWindow: Window_TitleCommand;
+
+ /**
+  * The background sprite which loads the $dataSystem.title1Name image.
+  */
+ @:native("_backSprite1")
+ public var __backSprite1: Sprite;
+
+ /**
+  * The background sprite which loads the $dataSystem.title2Name image.
+  */
+ @:native("_backSprite2")
+ public var __backSprite2: Sprite;
+
+ /**
+  * The sprite which holds the game title text.
+  */
+ @:native("_gameTitleSprite")
+ public var __gameTitleSprite: Sprite;
+
+ /**
+  * The command window for title scene commands like new game, continue, or options.
+  */
  private var _commandWindow: Window_TitleCommand;
 
  /**


### PR DESCRIPTION
Adds a few missing private variables form the Scene_Title class, also adds public access via native metadata.