### PR TITLE
Fix tilemap typo

### DIFF
--- a/src/rm/core/ShaderTileMap.hx
+++ b/src/rm/core/ShaderTileMap.hx
@@ -1,6 +1,6 @@
 package rm.core;
 
-import rm.core.TileMap.Tilemap;
+import rm.core.Tilemap;
 import pixi.core.renderers.webgl.Renderer;
 import pixi.core.renderers.canvas.CanvasRenderer;
 import pixi.core.renderers.AbstractRenderer;

--- a/src/rm/core/Tilemap.hx
+++ b/src/rm/core/Tilemap.hx
@@ -3,7 +3,7 @@ package rm.core;
 import pixi.core.display.DisplayObject;
 import pixi.core.display.Container;
 
-@:native("TileMap")
+@:native("Tilemap")
 extern class Tilemap extends Container {
  // Tile type checkers
  public static var TILE_ID_A1: Int;


### PR DESCRIPTION
Fixes a typo in the Tilemap class and the filename.

Closes #15 