### PR TITLE
Fix whitespace and recursive bug in parameter parser

### DIFF
--- a/src/utils/Parse.hx
+++ b/src/utils/Parse.hx
@@ -11,21 +11,24 @@ class Parse {
   */
  public static function parseParameters(parameters: String): Any {
   return Syntax.code("(function (string) {
-    var temp;
-    try {
-        temp = JsonEx.parse(typeof string === 'object ' ? JsonEx.stringify(string) : string);
-    } catch (e) {
-        return string;
+    function superParse (string) {
+      var temp;
+      try {
+          temp = JsonEx.parse(typeof string === 'object' ? JsonEx.stringify(string) : string);
+      } catch (e) {
+          return string;
+      }
+      if (typeof temp === 'object') {
+          Object.keys(temp).forEach(function (key) {
+              temp[key] = superParse(temp[key]);
+              if (temp[key] === ' ') {
+                  temp[key] = null;
+              }
+          });
+      }
+      return temp;
     }
-    if (typeof temp === 'object ') {
-        Object.keys(temp).forEach(function (key) {
-            temp[key] = JSONSuperParse(temp[key]);
-            if (temp[key] === ' ') {
-                temp[key] = null;
-            }
-        });
-    }
-    return temp;
+    return superParse(JsonEx.stringify(string));
 })({0})", parameters);
  }
 


### PR DESCRIPTION
Fixes a few bugs in the parameter parser.

- 🐛Fix the method not calling itself, breaking recursive parsing
- 🐛Fix whitespace when checking if string is typeof object.