### PR TITLE
Add new macro Patch class

### DIFF
--- a/src/macros/Patch.hx
+++ b/src/macros/Patch.hx
@@ -48,11 +48,15 @@ class Patch {
  macro public static function applyInline() {
   var localClass = Context.getLocalClass().get();
   var staticFields = localClass.statics.get();
+  var calledFromFieldName = Context.getLocalMethod().toString();
 
   var string = localClass.statics.toString();
   var expressions: Array<Expr> = [];
 
   for (field in staticFields) {
+   if (field.name == calledFromFieldName) {
+     continue;
+   }
    switch (field.kind.getParameters()) {
       case [MethInline]:
         var name = field.name;

--- a/src/macros/Patch.hx
+++ b/src/macros/Patch.hx
@@ -50,7 +50,6 @@ class Patch {
   var staticFields = localClass.statics.get();
   var calledFromFieldName = Context.getLocalMethod().toString();
 
-  var string = localClass.statics.toString();
   var expressions: Array<Expr> = [];
 
   for (field in staticFields) {

--- a/src/macros/Patch.hx
+++ b/src/macros/Patch.hx
@@ -1,0 +1,100 @@
+package macros;
+
+import haxe.macro.MacroStringTools;
+import haxe.macro.Type.FieldKind;
+import haxe.macro.Type.MethodKind;
+import haxe.macro.Type.ModuleType;
+import haxe.macro.Compiler;
+import haxe.macro.Type.ClassField;
+import haxe.macro.Expr;
+import haxe.macro.Expr.ExprDef;
+import haxe.macro.ExprTools;
+import haxe.macro.Expr.Access;
+import haxe.macro.Expr.FieldType;
+import haxe.macro.Context;
+import haxe.macro.Expr.Field;
+
+using Lambda;
+using haxe.macro.ComplexTypeTools;
+
+class Patch {
+ private static inline function _getFieldsByMetaName(fields: Array<Field>,
+   metaName: String): Array<Field> {
+  var result: Array<Field> = [];
+  var metaFields = fields.filter(f -> f.meta.length > 0);
+
+  for (field in metaFields) {
+   for (meta in field.meta) {
+    if (meta.name == metaName) {
+     result.push(field);
+    }
+   }
+  }
+  return result;
+ }
+
+ private static function createField(fieldName, value, pos): Field {
+  var newField: Field = {
+   name: fieldName,
+   access: [Access.APublic,
+    Access.AStatic],
+   kind: FieldType.FVar(macro:Dynamic, $v{value}),
+   pos: pos
+  }
+
+  return newField;
+ }
+
+ macro public static function applyInline() {
+  var localClass = Context.getLocalClass().get();
+  var staticFields = localClass.statics.get();
+
+  var string = localClass.statics.toString();
+  var expressions: Array<Expr> = [];
+
+  for (field in staticFields) {
+   switch (field.kind.getParameters()) {
+      case [MethInline]:
+        var name = field.name;
+        expressions.push(macro $i{name}());
+      default: 
+    }
+  }
+  return macro $b{expressions}
+ }
+
+ macro public static function rmClass(original: Dynamic, protoT: Dynamic, selfT: Dynamic): Array<Field> {
+  var localFields = Context.getBuildFields();
+
+  var selfFunc: Function = {
+   expr: macro return $selfT,
+   ret: (macro: Dynamic),
+   args: []
+  }
+  var protoFunc: Function = {
+   expr: macro return $original,
+   ret: (macro: Dynamic),
+   args: []
+  }
+
+  localFields.push({
+   name: '_self',
+   doc: null,
+   meta: [],
+   access: [Access.APublic, Access.AStatic, Access.AInline],
+   kind: FFun(selfFunc),
+   pos: Context.currentPos()
+  });
+
+  localFields.push({
+   name: '_proto',
+   doc: null,
+   meta: [],
+   access: [Access.APublic, Access.AStatic, Access.AInline],
+   kind: FFun(protoFunc),
+   pos: Context.currentPos()
+  });
+
+  return localFields;
+ }
+}

--- a/src/macros/Patch.hx
+++ b/src/macros/Patch.hx
@@ -33,18 +33,6 @@ class Patch {
   return result;
  }
 
- private static function createField(fieldName, value, pos): Field {
-  var newField: Field = {
-   name: fieldName,
-   access: [Access.APublic,
-    Access.AStatic],
-   kind: FieldType.FVar(macro:Dynamic, $v{value}),
-   pos: pos
-  }
-
-  return newField;
- }
-
  macro public static function applyInline() {
   var localClass = Context.getLocalClass().get();
   var staticFields = localClass.statics.get();

--- a/src/macros/Patch.hx
+++ b/src/macros/Patch.hx
@@ -72,7 +72,7 @@ class Patch {
    args: []
   }
   var protoFunc: Function = {
-   expr: macro return $original,
+   expr: macro return $protoT,
    ret: (macro: Dynamic),
    args: []
   }

--- a/src/macros/Patch.hx
+++ b/src/macros/Patch.hx
@@ -33,6 +33,10 @@ class Patch {
   return result;
  }
 
+ /** 
+   Finds all inline methods within the class its called from and calls each
+   inline method it finds.
+ **/
  macro public static function applyInline() {
   var localClass = Context.getLocalClass().get();
   var staticFields = localClass.statics.get();
@@ -54,7 +58,14 @@ class Patch {
   return macro $b{expressions}
  }
 
- macro public static function rmClass(original: Dynamic, protoT: Dynamic, selfT: Dynamic): Array<Field> {
+ /**
+  * **EXPERIMENTAL:** This macro adds 2 new fields `_proto` and `_self` both are
+  * inline method used to quicly override, alias or extend rm classes.
+  * @param protoT The prototype of the class you want proto and self to use
+  * @param selfT The native js `this`, use `js.lib.nativeThis` or `Fn.self`
+  * @return Array<Field>
+  */
+ macro public static function rmClass(protoT: Dynamic, selfT: Dynamic): Array<Field> {
   var localFields = Context.getBuildFields();
 
   var selfFunc: Function = {


### PR DESCRIPTION
A macro class that will help perform common actions that are required for aliasing and overriding default RPG Maker class methods.

This will be a class that is slowly worked on as we develop plugins.